### PR TITLE
New Sampling Method

### DIFF
--- a/RTG.py
+++ b/RTG.py
@@ -65,9 +65,9 @@ class RandomTeamGenerator:
     for team in teams:
       team += ['X'] * (max_len - len(team))
 
-    result_text = "Team 1:\n" + ", ".join(teams[0]) + "\n\n"
-    result_text += "Team 2:\n" + ", ".join(teams[1]) + "\n\n"
-    result_text += "Team 3:\n" + ", ".join(teams[2])
+    result_text = "Team 1 (OVR " + str(teams_weights[0]) + "):\n" + ", ".join(teams[0]) + "\n\n"
+    result_text += "Team 2 (OVR " + str(teams_weights[1]) + "):\n" + ", ".join(teams[1]) + "\n\n"
+    result_text += "Team 3 (OVR " + str(teams_weights[2]) + "):\n" + ", ".join(teams[2])
     
     self.result_label.config(text=result_text)
 

--- a/RTG.py
+++ b/RTG.py
@@ -52,12 +52,12 @@ class RandomTeamGenerator:
     random.shuffle(names3)
     teams = [[], [], []]
     weights = [(3, name) for name in names1] + [(2, name) for name in names2] + [(1, name) for name in names3]
-    new_weights = [0, 0, 0]
+    teams_weights = [0, 0, 0]
     
     for weight, name in weights:
-      min_index = new_weights.index(min(new_weights))
+      min_index = teams_weights.index(min(teams_weights))
       teams[min_index].append(name)
-      new_weights[min_index] += weight
+      teams_weights[min_index] += weight
 
     # Fill smaller teams with placeholders
     len_teams = [len(team) for team in teams]

--- a/RTG.py
+++ b/RTG.py
@@ -51,10 +51,20 @@ class RandomTeamGenerator:
     random.shuffle(names2)
     random.shuffle(names3)
     teams = [[], [], []]
+    weights = [(3, name) for name in names1] + [(2, name) for name in names2] + [(1, name) for name in names3]
+    new_weights = [0, 0, 0]
     
-    for i, name in enumerate(names1+names2+names3):
-        teams[i % 3].append(name)
-    
+    for weight, name in weights:
+      min_index = new_weights.index(min(new_weights))
+      teams[min_index].append(name)
+      new_weights[min_index] += weight
+
+    # Fill smaller teams with placeholders
+    len_teams = [len(team) for team in teams]
+    max_len = max(len_teams)
+    for team in teams:
+      team += ['X'] * (max_len - len(team))
+
     result_text = "Team 1:\n" + ", ".join(teams[0]) + "\n\n"
     result_text += "Team 2:\n" + ", ".join(teams[1]) + "\n\n"
     result_text += "Team 3:\n" + ", ".join(teams[2])


### PR DESCRIPTION
Added a greedy sampling method that will try to balance the teams based on a predefined weight for each value urn. 

### Sampling method
The basic idea is to have all the names into a list of weights (tuples with weight and name), in a descending order from their weight (the names should be still randomly shuffled). Then we proceed with a greedy method to parse this list and add a member in the team with the lowest current weight. We start with higher values in the list for a better weight distribution across all teams.
For the 3 urns, the values 3, 2, 1 will be used where 3 is for the first urn, which is the most valuable.

#### Example
In the following screenshot we can see the first teams has 1 more player from the first urn, but more players from the third urn for a more balanced combat.
![image](https://github.com/muresanuliviu/RTG/assets/15572754/4e04a75f-56b0-4050-8b8e-887542e15d7e)


### Other updates
In the same commit, there was added a change where smaller teams will be filled with an 'X' as a placeholder:
![image](https://github.com/muresanuliviu/RTG/assets/15572754/3122a754-3248-461a-aedc-ad6f330ce555)

